### PR TITLE
Artifact tagging

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -79,7 +79,8 @@ Authorization: Bearer {token}
     "description": "Artifact description",
     "owners": [],
     "groups": [],
-    "sharedWith": []
+    "sharedWith": [],
+    "tags": []
 }
 ```
 
@@ -101,9 +102,10 @@ following differences:
 Get all artifact a user has access to (owns, group they're part of, shared
 with). This endpoint also accepts the following query parameters:
 
-- `group (int)` - Only return artifacts that are associated with the group with ID
+- `group` (int) - Only return artifacts that are associated with the group with ID
 - `owner` (int) - Only return artifacts that are owned by the user with this ID
 - `shared` (int) - Only return artifacts shared with the user with this ID
+- `tag` (string) - Only return artifacts with this tag
 
 None of the query parameters are required and they can be used together to
 further filter the returned artifacts.
@@ -164,7 +166,8 @@ Authorization: Bearer {token}
     "description": "Artifact description",
     "owners": [],
     "groups": [],
-    "sharedWith": []
+    "sharedWith": [],
+    "tag": []
 }
 ```
 

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/Artifact.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/Artifact.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo
 import com.fasterxml.jackson.annotation.JsonIdentityReference
 import com.fasterxml.jackson.annotation.ObjectIdGenerators
 import javax.persistence.CascadeType
+import javax.persistence.ElementCollection
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
@@ -41,7 +42,10 @@ data class Artifact(
     @OneToMany(cascade = [CascadeType.ALL])
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator::class, property = "id")
     @JsonIdentityReference(alwaysAsId = true)
-    val resources: MutableList<ArtifactResource> = mutableListOf()
+    val resources: MutableList<ArtifactResource> = mutableListOf(),
+    @LazyCollection(value = LazyCollectionOption.FALSE)
+    @ElementCollection
+    val tags: MutableList<String> = mutableListOf()
 ) {
     override fun toString(): String {
         return listOf(
@@ -50,7 +54,8 @@ data class Artifact(
             "description=$description",
             "owners=${owners.map(User::id)}",
             "groups=${groups.map(Group::id)}",
-            "sharedwith=${sharedWith.map(User::id)}"
+            "sharedwith=${sharedWith.map(User::id)}",
+            "tags=$tags"
         ).joinToString(separator = ", ", prefix = "Artifact(", postfix = ")")
     }
 }

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactController.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactController.kt
@@ -80,7 +80,8 @@ class ArtifactController(
             ownerIDs = newArtifact.owners ?: listOf(),
             groupIDs = newArtifact.groups ?: listOf(),
             sharedWith = newArtifact.sharedWith ?: listOf(),
-            resourceIDs = newArtifact.resources ?: listOf()
+            resourceIDs = newArtifact.resources ?: listOf(),
+            tags = newArtifact.tags ?: listOf()
         )
         logger.info("Created artifact $createdArtifact")
         return ResponseEntity.status(HttpStatus.CREATED).body(createdArtifact)

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactController.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactController.kt
@@ -36,7 +36,8 @@ class ArtifactController(
     fun getArtifacts(
         @RequestParam(name = "group", required = false) groupID: Long?,
         @RequestParam(name = "owner", required = false) ownerID: Long?,
-        @RequestParam(name = "shared", required = false) sharedID: Long?
+        @RequestParam(name = "shared", required = false) sharedID: Long?,
+        @RequestParam(name = "tag", required = false) tag: String?
     ): ResponseEntity<List<Artifact>> {
         val currentUser = SecurityContextHolder.getContext().authentication
         logger.debug("Filtering artifacts for ${currentUser.principal} by group=$groupID, owner=$ownerID, shared=$sharedID")
@@ -45,7 +46,8 @@ class ArtifactController(
                 email = currentUser.principal as String,
                 groupID = groupID,
                 ownerID = ownerID,
-                sharedID = sharedID
+                sharedID = sharedID,
+                tag = tag
             )
         logger.debug("Found ${artifacts.size} artifacts fitting the criteria")
 

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactController.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactController.kt
@@ -119,21 +119,3 @@ class ArtifactController(
         return ResponseEntity.ok(deletedArtifact)
     }
 }
-
-/**
- * [ArtifactRequest] represents a request to create an artifact.
- *
- * @param [name] Name of the artifact
- * @param [description] Description of the artifact
- * @param [owners] User IDs of the users to be made owners of the artifact
- * @param [groups] Group IDs of the groups to be associated with the artifact
- * @param [sharedWith] User IDs of the users to share the artifact with
- */
-data class ArtifactRequest(
-    val name: String,
-    val description: String,
-    val owners: List<Long>?,
-    val groups: List<Long>?,
-    val sharedWith: List<Long>?,
-    val resources: List<Long>? = listOf()
-)

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactRequest.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactRequest.kt
@@ -1,0 +1,20 @@
+package com.synergeticsolutions.familyartefacts
+
+/**
+ * [ArtifactRequest] represents a request to create an artifact.
+ *
+ * @param [name] Name of the artifact
+ * @param [description] Description of the artifact
+ * @param [owners] User IDs of the users to be made owners of the artifact
+ * @param [groups] Group IDs of the groups to be associated with the artifact
+ * @param [sharedWith] User IDs of the users to share the artifact with
+ */
+data class ArtifactRequest(
+    val name: String,
+    val description: String,
+    val owners: List<Long>?,
+    val groups: List<Long>?,
+    val sharedWith: List<Long>?,
+    val resources: List<Long>? = listOf(),
+    val tags: List<String>? = listOf()
+)

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactService.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactService.kt
@@ -17,7 +17,8 @@ interface ArtifactService {
         ownerIDs: List<Long> = listOf(),
         groupIDs: List<Long> = listOf(),
         sharedWith: List<Long> = listOf(),
-        resourceIDs: List<Long> = listOf()
+        resourceIDs: List<Long> = listOf(),
+        tags: List<String> = listOf()
     ): Artifact
 
     fun updateArtifact(email: String, id: Long, update: ArtifactRequest): Artifact

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactService.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactService.kt
@@ -5,7 +5,8 @@ interface ArtifactService {
         email: String,
         groupID: Long? = null,
         ownerID: Long? = null,
-        sharedID: Long? = null
+        sharedID: Long? = null,
+        tag: String? = null
     ): List<Artifact>
 
     fun findArtifactById(email: String, id: Long): Artifact

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactServiceImpl.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactServiceImpl.kt
@@ -118,7 +118,7 @@ class ArtifactServiceImpl(
      * @return Collection of artifacts the user has access to filtered by the given parameters
      * @throws UserNotFoundException when a user with [email] does not exist
      */
-    override fun findArtifactsByOwner(email: String, groupID: Long?, ownerID: Long?, sharedID: Long?): List<Artifact> {
+    override fun findArtifactsByOwner(email: String, groupID: Long?, ownerID: Long?, sharedID: Long?, tag: String?): List<Artifact> {
         val user =
             userRepository.findByEmail(email) ?: throw UserNotFoundException("No user with email $email was found")
 
@@ -138,6 +138,10 @@ class ArtifactServiceImpl(
 
         if (sharedID != null) {
             artifacts = artifacts.filter { it.sharedWith.map(User::id).contains(sharedID) }
+        }
+
+        if (tag != null) {
+            artifacts = artifacts.filter { it.tags.contains(tag) }
         }
 
         return artifacts

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactServiceImpl.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactServiceImpl.kt
@@ -255,20 +255,15 @@ class ArtifactServiceImpl(
         // Other than owners, the only users that can make any sort of modifications are group owners of groups the
         // artifact is in. In this case, they're limited to being able to remove an artifact from a group they're an
         // owner of.
-        when {
-            update.name != artifact.name -> throw ActionNotAllowedException("User ${user.id} is not an owner of artifact ${artifact.id}")
-            update.description != artifact.description -> throw ActionNotAllowedException("User ${user.id} is not an owner of artifact ${artifact.id}")
-            update.owners != artifact.owners.map(User::id) -> throw ActionNotAllowedException("User ${user.id} is not an owner of artifact ${artifact.id}")
-            update.sharedWith != artifact.sharedWith.map(User::id) -> throw ActionNotAllowedException("User ${user.id} is not an owner of artifact ${artifact.id}")
-            update.resources != artifact.resources.map(ArtifactResource::id) -> throw ActionNotAllowedException("User ${user.id} is not an owner of artifact ${artifact.id}")
-            update.groups != artifact.groups.map(Group::id) -> {
-                // The set of groups a user removes must be a subset of the set groups in which they are an owner
-                val removedGroups = artifact.groups.map(Group::id).subtract(update.groups!!)
-                if (!user.ownedGroups.map(Group::id).containsAll(removedGroups.toList())) {
-                    throw ActionNotAllowedException("User ${user.id} is not an admin of all the groups they attempted to remove")
-                }
+        if (update.groups != artifact.groups.map(Group::id)) {
+            // The set of groups a user removes must be a subset of the set groups in which they are an owner
+            val removedGroups = artifact.groups.map(Group::id).subtract(update.groups!!)
+            if (!user.ownedGroups.map(Group::id).containsAll(removedGroups.toList())) {
+                throw ActionNotAllowedException("User ${user.id} is not an admin of all the groups they attempted to remove")
             }
-            else -> throw ActionNotAllowedException("User ${user.id} is not an owner of artifact ${artifact.id}")
+        }
+        else {
+            throw ActionNotAllowedException("User ${user.id} is not an owner of artifact ${artifact.id}")
         }
     }
 

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactServiceImpl.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactServiceImpl.kt
@@ -21,6 +21,7 @@ class ArtifactServiceImpl(
     @Autowired
     val artifactResourceRepository: ArtifactResourceRepository
 ) : ArtifactService {
+
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     /**
@@ -264,8 +265,7 @@ class ArtifactServiceImpl(
             if (!user.ownedGroups.map(Group::id).containsAll(removedGroups.toList())) {
                 throw ActionNotAllowedException("User ${user.id} is not an admin of all the groups they attempted to remove")
             }
-        }
-        else {
+        } else {
             throw ActionNotAllowedException("User ${user.id} is not an owner of artifact ${artifact.id}")
         }
     }

--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactServiceImpl.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/ArtifactServiceImpl.kt
@@ -43,7 +43,8 @@ class ArtifactServiceImpl(
         ownerIDs: List<Long>,
         groupIDs: List<Long>,
         sharedWith: List<Long>,
-        resourceIDs: List<Long>
+        resourceIDs: List<Long>,
+        tags: List<String>
     ): Artifact {
         val creator =
             userRepository.findByEmail(email) ?: throw UserNotFoundException("No user with email $email was found")
@@ -81,7 +82,8 @@ class ArtifactServiceImpl(
             owners = owners,
             groups = groups,
             sharedWith = shares,
-            resources = resources
+            resources = resources,
+            tags = tags.toMutableList()
         )
         val savedArtifact = artifactRepository.save(artifact)
 
@@ -241,7 +243,8 @@ class ArtifactServiceImpl(
             description = update.description,
             owners = updatedOwners,
             groups = updatedGroups,
-            sharedWith = updatedShares
+            sharedWith = updatedShares,
+            tags = update.tags?.toMutableList() ?: mutableListOf()
         )
         return artifactRepository.save(updatedArtifact)
     }

--- a/src/test/kotlin/com/synergeticsolutions/familyartefacts/ArtifactControllerTest.kt
+++ b/src/test/kotlin/com/synergeticsolutions/familyartefacts/ArtifactControllerTest.kt
@@ -201,7 +201,7 @@ class ArtifactControllerTest {
                 )
             }
             artifactService.createArtifact(
-                email = "example2@example.com",
+                email = email,
                 name = "artifact3",
                 description = "desc",
                 ownerIDs = listOf(),

--- a/src/test/kotlin/com/synergeticsolutions/familyartefacts/ArtifactControllerTest.kt
+++ b/src/test/kotlin/com/synergeticsolutions/familyartefacts/ArtifactControllerTest.kt
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.greaterThan
 import org.hamcrest.Matchers.hasEntry
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.hasItems
@@ -14,7 +16,6 @@ import org.hamcrest.Matchers.not
 import org.hamcrest.collection.IsCollectionWithSize.hasSize
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -50,6 +51,9 @@ class ArtifactControllerTest {
 
     @Autowired
     lateinit var artifactService: ArtifactService
+
+    @Autowired
+    lateinit var groupService: GroupService
 
     @Autowired
     private lateinit var testUtils: TestUtilsService
@@ -180,6 +184,43 @@ class ArtifactControllerTest {
         }
 
         @Test
+        fun `it should filter the artifacts by the given tag`() {
+            userService.createUser("name2", "example2@example.com", "password")
+            val artifacts = listOf(
+                "artifact1",
+                "artifact2"
+            ).map {
+                artifactService.createArtifact(
+                    email = email,
+                    name = it,
+                    description = "description",
+                    ownerIDs = listOf(),
+                    groupIDs = listOf(),
+                    sharedWith = listOf(),
+                    tags = listOf("test")
+                )
+            }
+            artifactService.createArtifact(
+                email = "example2@example.com",
+                name = "artifact3",
+                description = "desc",
+                ownerIDs = listOf(),
+                groupIDs = listOf(),
+                sharedWith = listOf()
+            )
+            client.get()
+                .uri("/artifact?tag=test")
+                .accept(MediaType.APPLICATION_JSON_UTF8)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .exchange()
+                .expectStatus().isOk
+                .expectBody()
+                .jsonPath("$").isArray
+                .jsonPath("$").value(hasSize<Artifact>(artifacts.size))
+                .jsonPath("$").value(containsInAnyOrder(artifacts.map { hasEntry("id", it.id.toInt()) }))
+        }
+
+        @Test
         fun `it should filter the artifacts by the given group ID and owner ID`() {
             val usr1 = userRepository.findByEmail(email)!!
             val usr2 = userService.createUser("user2", "exampl2@example.com", "password")
@@ -229,18 +270,51 @@ class ArtifactControllerTest {
                     )
                 }))
         }
+
+        @Test
+        fun `it should get the artifact by ID`() {
+            val usr = userRepository.findByEmail(email)!!
+            val artifact = artifactService.createArtifact(
+                email = usr.email,
+                name = "artifact3",
+                description = "desc",
+                ownerIDs = listOf(),
+                groupIDs = listOf(),
+                sharedWith = listOf(),
+                tags = listOf("test1", "test2")
+            )
+            client.get()
+                .uri("/artifact/${artifact.id}")
+                .accept(MediaType.APPLICATION_JSON_UTF8)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .exchange()
+                .expectStatus().isOk
+                .expectBody()
+                .jsonPath("$").isNotEmpty
+                .jsonPath("$.id").value(`is`(artifact.id.toInt()))
+                .jsonPath("$.name").value(`is`(artifact.name))
+                .jsonPath("$.description").value(`is`(artifact.description))
+                .jsonPath("$.owners").value(`is`(artifact.owners.map { it.id.toInt() }))
+                .jsonPath("$.groups").value(`is`(artifact.groups.map { it.id.toInt() }))
+                .jsonPath("$.sharedWith").value(`is`(artifact.sharedWith.map { it.id.toInt() }))
+                .jsonPath("$.tags").value(`is`(artifact.tags))
+        }
     }
 
     @Nested
     inner class CreateArtifact {
         @Test
         fun `it should create the artifact`() {
+            val user = userRepository.findByEmail(email)!!
+            val user2 = userService.createUser("user2", "example2@example.com", "password")
+            val group = groupService.createGroup(user.email, "group1", "description", memberIDs = listOf(user2.id))
             val artifactRequest = ArtifactRequest(
                 name = "Artifact 1",
                 description = "Description",
                 owners = listOf(),
-                groups = listOf(),
-                sharedWith = listOf()
+                groups = listOf(group.id),
+                sharedWith = listOf(user2.id),
+                tags = listOf("test1", "test2")
             )
             val response = client.post()
                 .uri("/artifact")
@@ -251,15 +325,29 @@ class ArtifactControllerTest {
                 .exchange()
                 .expectStatus().isCreated
                 .expectBody()
+                .jsonPath("$.id").value(greaterThan(0))
+                .jsonPath("$.name").value(`is`(artifactRequest.name))
+                .jsonPath("$.description").value(`is`(artifactRequest.description))
+                .jsonPath("$.owners").value(`is`(listOf(user.id.toInt())))
+                .jsonPath("$.groups").value(containsInAnyOrder(user.privateGroup.id.toInt(), group.id.toInt()))
+                .jsonPath("$.sharedWith").value(`is`(listOf(user2.id.toInt())))
+                .jsonPath("$.tags").value(`is`(artifactRequest.tags))
                 .returnResult()
                 .responseBody!!
             val returnedArtifact = ObjectMapper().registerKotlinModule().readValue<Map<String, Any>>(String(response))
-            assertTrue((returnedArtifact["id"] as Int) > 0)
-            assertEquals(returnedArtifact["name"] as String, artifactRequest.name)
-            assertEquals(returnedArtifact["description"] as String, artifactRequest.description)
 
             val createdArtifact = artifactRepository.findByIdOrNull((returnedArtifact["id"] as Int).toLong())!!
-            assertEquals(mutableListOf(userRepository.findByEmail(email)!!.id), createdArtifact.owners.map(User::id))
+            // Check owners
+            assertThat(createdArtifact.owners.map(User::id), contains(`is`(user.id)))
+
+            // Check groups
+            assertThat(createdArtifact.groups.map(Group::id), containsInAnyOrder(group.id, user.privateGroup.id))
+
+            // Check shared with
+            assertThat(createdArtifact.sharedWith.map(User::id), contains(user2.id))
+
+            // Check tags
+            assertThat(createdArtifact.tags, containsInAnyOrder(*(artifactRequest.tags!!.toTypedArray())))
         }
     }
 
@@ -477,6 +565,150 @@ class ArtifactControllerTest {
                     .expectStatus().isBadRequest
                     .expectBody()
                     .jsonPath("$.message").value(`is`("Cannot remove resources in artifact update"))
+            }
+
+            @Test
+            fun `it should add the specified users as owners`() {
+                val artifact = artifactService.createArtifact(email, "artifact", "description")
+                val user = userRepository.findByEmail(email)!!
+                val user2 = userService.createUser("user2", "example2@example.com", "password")
+                val updateArtifactRequest = ArtifactRequest(
+                    name = artifact.name,
+                    description = artifact.description,
+                    owners = artifact.owners.map(User::id) + listOf(user2.id),
+                    groups = listOf(),
+                    sharedWith = listOf(),
+                    tags = listOf()
+                )
+                val updateArtifactResponse = client.put()
+                    .uri("/artifact/${artifact.id}")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .syncBody(updateArtifactRequest)
+                    .exchange()
+                    .expectStatus().isOk
+                    .expectBody()
+                    .jsonPath("$.id").value(`is`(artifact.id.toInt()))
+                    .jsonPath("$.name").value(`is`(updateArtifactRequest.name))
+                    .jsonPath("$.description").value(`is`(updateArtifactRequest.description))
+                    .jsonPath("$.owners").value(`is`(updateArtifactRequest.owners!!.map(Long::toInt)))
+                    .jsonPath("$.groups").value(`is`(updateArtifactRequest.groups!!.map(Long::toInt)))
+                    .jsonPath("$.sharedWith").value(`is`(updateArtifactRequest.sharedWith!!.map(Long::toInt)))
+                    .jsonPath("$.tags").value(`is`(updateArtifactRequest.tags))
+                    .returnResult()
+                    .responseBody!!
+                val response = ObjectMapper().registerKotlinModule().readValue<Map<String, Any>>(updateArtifactResponse)
+                val updatedArtifact = artifactRepository.findByIdOrNull((response.getValue("id") as Int).toLong())!!
+                val updatedUser = userRepository.findByIdOrNull(user.id)!!
+                val updatedUser2 = userRepository.findByIdOrNull(user2.id)!!
+                assertThat(updatedArtifact.owners.map(User::id), containsInAnyOrder(user.id, user2.id))
+            }
+
+            @Test
+            fun `it should add the artifact to the specified groups`() {
+                val artifact = artifactService.createArtifact(email, "artifact", "description")
+                val user = userRepository.findByEmail(email)
+                val group = groupService.createGroup(email, "group 1", "description", memberIDs = listOf())
+                val updateArtifactRequest = ArtifactRequest(
+                    name = artifact.name,
+                    description = artifact.description,
+                    owners = listOf(),
+                    groups = listOf(group.id),
+                    sharedWith = listOf(),
+                    tags = listOf()
+                )
+                val updateArtifactResponse = client.put()
+                    .uri("/artifact/${artifact.id}")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .syncBody(updateArtifactRequest)
+                    .exchange()
+                    .expectStatus().isOk
+                    .expectBody()
+                    .jsonPath("$.id").value(`is`(artifact.id.toInt()))
+                    .jsonPath("$.name").value(`is`(updateArtifactRequest.name))
+                    .jsonPath("$.description").value(`is`(updateArtifactRequest.description))
+                    .jsonPath("$.owners").value(`is`(updateArtifactRequest.owners!!.map(Long::toInt)))
+                    .jsonPath("$.groups").value(`is`(updateArtifactRequest.groups!!.map(Long::toInt)))
+                    .jsonPath("$.sharedWith").value(`is`(updateArtifactRequest.sharedWith!!.map(Long::toInt)))
+                    .jsonPath("$.tags").value(`is`(updateArtifactRequest.tags))
+                    .returnResult()
+                    .responseBody!!
+                val response = ObjectMapper().registerKotlinModule().readValue<Map<String, Any>>(updateArtifactResponse)
+                val updatedArtifact = artifactRepository.findByIdOrNull((response.getValue("id") as Int).toLong())!!
+                assertThat(updatedArtifact.groups.map(Group::id), containsInAnyOrder(group.id))
+            }
+
+            @Test
+            fun `it should share the artifact with the specified users`() {
+                val artifact = artifactService.createArtifact(email, "artifact", "description")
+                val user = userRepository.findByEmail(email)
+                val user2 = userService.createUser("user2", "example2@example.com", "password")
+                val updateArtifactRequest = ArtifactRequest(
+                    name = artifact.name,
+                    description = artifact.description,
+                    owners = listOf(),
+                    groups = listOf(),
+                    sharedWith = listOf(user2.id),
+                    tags = listOf()
+                )
+                val updateArtifactResponse = client.put()
+                    .uri("/artifact/${artifact.id}")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .syncBody(updateArtifactRequest)
+                    .exchange()
+                    .expectStatus().isOk
+                    .expectBody()
+                    .jsonPath("$.id").value(`is`(artifact.id.toInt()))
+                    .jsonPath("$.name").value(`is`(updateArtifactRequest.name))
+                    .jsonPath("$.description").value(`is`(updateArtifactRequest.description))
+                    .jsonPath("$.owners").value(`is`(updateArtifactRequest.owners!!.map(Long::toInt)))
+                    .jsonPath("$.groups").value(`is`(updateArtifactRequest.groups!!.map(Long::toInt)))
+                    .jsonPath("$.sharedWith").value(`is`(updateArtifactRequest.sharedWith!!.map(Long::toInt)))
+                    .jsonPath("$.tags").value(`is`(updateArtifactRequest.tags))
+                    .returnResult()
+                    .responseBody!!
+                val response = ObjectMapper().registerKotlinModule().readValue<Map<String, Any>>(updateArtifactResponse)
+                val updatedArtifact = artifactRepository.findByIdOrNull((response.getValue("id") as Int).toLong())!!
+                assertThat(updatedArtifact.sharedWith.map(User::id), containsInAnyOrder(user2.id))
+            }
+
+            @Test
+            fun `it should add the specified tags to the artifact`() {
+                val artifact = artifactService.createArtifact(email, "artifact", "description")
+                val updateArtifactRequest = ArtifactRequest(
+                    name = artifact.name,
+                    description = artifact.description,
+                    owners = listOf(),
+                    groups = listOf(),
+                    sharedWith = listOf(),
+                    tags = listOf("tag1", "tag2")
+                )
+                val updateArtifactResponse = client.put()
+                    .uri("/artifact/${artifact.id}")
+                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .contentType(MediaType.APPLICATION_JSON_UTF8)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .syncBody(updateArtifactRequest)
+                    .exchange()
+                    .expectStatus().isOk
+                    .expectBody()
+                    .jsonPath("$.id").value(`is`(artifact.id.toInt()))
+                    .jsonPath("$.name").value(`is`(updateArtifactRequest.name))
+                    .jsonPath("$.description").value(`is`(updateArtifactRequest.description))
+                    .jsonPath("$.owners").value(`is`(updateArtifactRequest.owners!!.map(Long::toInt)))
+                    .jsonPath("$.groups").value(`is`(updateArtifactRequest.groups!!.map(Long::toInt)))
+                    .jsonPath("$.sharedWith").value(`is`(updateArtifactRequest.sharedWith!!.map(Long::toInt)))
+                    .jsonPath("$.tags").value(`is`(updateArtifactRequest.tags))
+                    .returnResult()
+                    .responseBody!!
+                val response = ObjectMapper().registerKotlinModule().readValue<Map<String, Any>>(updateArtifactResponse)
+                val updatedArtifact = artifactRepository.findByIdOrNull((response.getValue("id") as Int).toLong())!!
+                assertThat(updatedArtifact.tags, containsInAnyOrder(*(updateArtifactRequest.tags!!.toTypedArray())))
             }
         }
 


### PR DESCRIPTION
Implements tagging of artifacts. Tags are just are currently just simple strings not linked to any entities. They can be used to group artifacts together.

- Added `tags` field to the `Artifact` entity, `tags` field is a collection of strings
- Allowed filtering by tag on the `GET /artifact` endpoiont using the `tag` query parameter