### PR TITLE
fixed updateGroup

### DIFF
--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/GroupService.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/GroupService.kt
@@ -8,13 +8,9 @@ interface GroupService {
         memberIDs: List<Long>,
         adminIDs: List<Long>
     ): Group
-    fun removeAdmins(email: String, adminsToRemove: List<User>, group: Group): Group
     fun findGroups(email: String, adminID: Long?, memberID: Long?): List<Group>
     fun deleteGroup(email: String, groupID: Long): Group
     fun updateGroup(email: String, groupID: Long, groupRequest: GroupRequest): Group
-    fun removeMembers(membersToRemove: List<User>, group: Group): Group
-    fun addAdmins(adminsToAdd: List<User>, group: Group): Group
-    fun addMembers(membersToAdd: List<User>, group: Group): Group
     fun findGroupById(email: String, groupID: Long): Group
     fun addImage(s: String, contentType: String, id: Long, image: ByteArray): Group
 }


### PR DESCRIPTION
I fixed updateGroup() to do everything within a single method (as in Artifact and Album updates), rather than 4 separate ones as before, since the logic was too clumsy to keep track of. I also added tests to make sure that members/admins are updated appropriately