### PR TITLE
Fix bug where user could attempt to update their email to that of an existing user

### DIFF
--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/UserServiceImpl.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/UserServiceImpl.kt
@@ -6,9 +6,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.web.bind.annotation.ResponseStatus
 
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 class UserAlreadyExistsException(msg: String) : AuthenticationException(msg)
 
 /**
@@ -127,6 +130,11 @@ class UserServiceImpl(
             if (it.password != null) {
                 password = passwordEncoder.encode(it.password)
             }
+
+            if ((it.email != user.email) && userRepository.findByEmail(it.email) != null) {
+                throw UserAlreadyExistsException("Cannot update user ${user.id} email to ${it.email} as there is already as user with that email")
+            }
+
             user = user.copy(name = it.name, email = it.email, password = password)
         }
 

--- a/src/test/kotlin/com/synergeticsolutions/familyartefacts/UserControllerTest.kt
+++ b/src/test/kotlin/com/synergeticsolutions/familyartefacts/UserControllerTest.kt
@@ -147,7 +147,7 @@ class UserControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .syncBody(registrationRequest)
                 .exchange()
-                .expectStatus().is5xxServerError
+                .expectStatus().isBadRequest
                 .expectBody().jsonPath("$.message").isEqualTo("User already exists with email $email")
         }
 
@@ -426,6 +426,15 @@ class UserControllerTest {
                 assertEquals(updatedName, updatedUser.name)
                 assertEquals(updatedEmail, updatedUser.email)
                 assertNotEquals(user.password, updatedUser.password)
+            }
+
+            @Test
+            fun `it cannot update a user's email to one that already exists`() {
+                client.put().uri("/user/${user.id}")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .syncBody(UserUpdateRequest(user.name, user2.email))
+                    .exchange()
+                    .expectStatus().isBadRequest
             }
         }
 

--- a/src/test/kotlin/com/synergeticsolutions/familyartefacts/UserServiceImplTest.kt
+++ b/src/test/kotlin/com/synergeticsolutions/familyartefacts/UserServiceImplTest.kt
@@ -227,13 +227,13 @@ class UserServiceImplUnitTest {
             val updatedUser = userService.update(
                 user1.email,
                 user1.id,
-                metadata = UserUpdateRequest("test", "test", null),
+                metadata = UserUpdateRequest("test", user1.email, null),
                 contentType = null
             )
             assertThat(updatedUser, allOf(
                 hasProperty("id", `is`(user1.id)),
                 hasProperty("name", `is`("test")),
-                hasProperty("email", `is`("test")),
+                hasProperty("email", `is`(user1.email)),
                 hasProperty("password", `is`(user1.password))
             ))
             Mockito.verify(userRepository).save(updatedUser)
@@ -261,7 +261,7 @@ class UserServiceImplUnitTest {
         fun `it should update both the metadata and the image if they're both specified`() {
             val updatedUser = userService.update(
                 user1.email, user1.id,
-                metadata = UserUpdateRequest("test", "test", null),
+                metadata = UserUpdateRequest("test", user1.email, null),
                 profilePicture = "profilePicture".toByteArray(),
                 contentType = null
             )


### PR DESCRIPTION
This was causing a constraint error when we tried to write to the database. This fix checks that there
is not already an existing user with the updated email. If there is it fails with a more informative error message