### PR TITLE
Don't ignore the content type when serialising the user

### DIFF
--- a/src/main/kotlin/com/synergeticsolutions/familyartefacts/User.kt
+++ b/src/main/kotlin/com/synergeticsolutions/familyartefacts/User.kt
@@ -65,7 +65,6 @@ data class User(
     @LazyToOne(value = LazyToOneOption.FALSE)
     val privateGroup: Group,
 
-    @JsonIgnore
     val contentType: String? = null,
     @JsonIgnore
     @Lob


### PR DESCRIPTION
Include the user's profile picture's content type when serialising the user entity to JSON